### PR TITLE
Add birthday scopes to the Fact model

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
@@ -87,6 +89,7 @@ group :development, :test do
   gem 'factory_bot_rails'
   gem 'rails-controller-testing'
   gem 'rspec-rails', '~> 4.0.0'
+  gem 'timecop'
 end
 
 # Use Devise for authentication

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -469,6 +469,7 @@ GEM
     temple (0.8.2)
     thor (1.1.0)
     tilt (2.0.10)
+    timecop (0.9.4)
     turbolinks (5.2.1)
       turbolinks-source (~> 5.2)
     turbolinks-source (5.2.0)
@@ -562,6 +563,7 @@ DEPENDENCIES
   solargraph
   spring
   stackprof
+  timecop
   turbolinks (~> 5)
   tzinfo-data
   web-console (>= 4.1.0)

--- a/app/models/concerns/sql_functions.rb
+++ b/app/models/concerns/sql_functions.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# Model to create SQL functions for common use
+module SqlFunctions
+  extend ActiveSupport::Concern
+
+  class_methods do
+    def add_valid_date_function
+      is_valid_date_function = <<-SQL.squish
+        create or replace function is_valid_date(str varchar)
+        returns boolean
+        language plpgsql as $$
+        begin
+          perform str::date;
+          return true;
+        exception when others then
+          return false;
+        end;
+        $$;
+      SQL
+      ActiveRecord::Base.connection.execute(is_valid_date_function)
+    end
+  end
+end

--- a/app/models/fact.rb
+++ b/app/models/fact.rb
@@ -7,7 +7,7 @@ class Fact < ApplicationRecord
   include SqlFunctions
 
   module Types
-    BIRTH_DATE = 'birth'
+    BIRTH = 'birth'
   end
 
   belongs_to :factable, polymorphic: true, optional: true
@@ -20,7 +20,7 @@ class Fact < ApplicationRecord
 
   before_save :update_normalized_type
 
-  scope :birth_dates, -> { where(fact_type: Types::BIRTH_DATE) }
+  scope :birth_dates, -> { where(fact_type: Types::BIRTH) }
   scope :birthdays_in_range, lambda { |start_date, end_date, limit|
     add_valid_date_function
     date_in_current_year =

--- a/app/models/fact.rb
+++ b/app/models/fact.rb
@@ -4,6 +4,11 @@
 # Factable objects: Person
 class Fact < ApplicationRecord
   include ParseableDate
+  include SqlFunctions
+
+  module Types
+    BIRTH_DATE = 'birth'
+  end
 
   belongs_to :factable, polymorphic: true, optional: true
   validates :fact_type, presence: true
@@ -14,6 +19,23 @@ class Fact < ApplicationRecord
   acts_as_taggable_on :tags, :tagged_people
 
   before_save :update_normalized_type
+
+  scope :birth_dates, -> { where(fact_type: Types::BIRTH_DATE) }
+  scope :birthdays_in_range, lambda { |start_date, end_date, limit|
+    add_valid_date_function
+    date_in_current_year =
+      "make_date(date_part('year', current_date)::int, date_part('month', date_string::date)::int, " \
+      "date_part('day', date_string::date)::int)"
+    includes(:factable)
+      .birth_dates
+      .where(
+        'CASE is_valid_date(date_string) WHEN true THEN ' \
+        "(#{date_in_current_year} >= ? AND #{date_in_current_year} <= ?) ELSE false END",
+        start_date, end_date
+      )
+      .order(Arel.sql(date_in_current_year))
+      .limit(limit)
+  }
 
   def date
     parse(date_string)

--- a/spec/models/fact_spec.rb
+++ b/spec/models/fact_spec.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Fact, type: :model do
+  describe '.birth_dates' do
+    let!(:birth_dates) { create_list(:fact, 2, fact_type: described_class::Types::BIRTH_DATE) }
+
+    it 'returns birth date facts' do
+      expect(described_class.birth_dates).to match_array birth_dates
+    end
+
+    context 'when there are non-birth date facts' do
+      let!(:non_birth_dates) { create_list(:fact, 2) }
+
+      it 'does not return non-birth date facts' do
+        expect(described_class.birth_dates & non_birth_dates).to eq []
+      end
+    end
+  end
+
+  describe '.birthdays_in_range' do
+    let(:birthday_range_start) { Time.zone.today }
+    let(:birthday_range_end) { Time.zone.today + 3.days }
+    let(:birthday_limit) { 5 }
+    let(:in_range_birthdays) do
+      Array.new(3) do |i|
+        create(
+          :fact,
+          fact_type: described_class::Types::BIRTH_DATE,
+          date_string: (Time.zone.today + i.days).strftime('%B %-d, %Y')
+        )
+      end
+    end
+
+    def birthdays_in_range
+      described_class.birthdays_in_range(birthday_range_start, birthday_range_end, birthday_limit)
+    end
+
+    before do
+      Timecop.travel(DateTime.current.change(hour: 12))
+      in_range_birthdays
+    end
+
+    after do
+      Timecop.return
+    end
+
+    it 'returns birthdays within the given range' do
+      expect(birthdays_in_range).to match_array in_range_birthdays
+    end
+
+    context 'when there are birthdays with invalid date formats' do
+      let!(:invalid_birthdays) do
+        [
+          create(:fact, fact_type: described_class::Types::BIRTH_DATE, date_string: 'text'),
+          create(:fact, fact_type: described_class::Types::BIRTH_DATE, date_string: '1998')
+        ]
+      end
+
+      it 'filters out birthdays with invalid date formats' do
+        expect(birthdays_in_range & invalid_birthdays).to eq []
+      end
+    end
+
+    context 'when there are birthdays in a variety of date formats' do
+      let!(:in_range_birthdays) do
+        [
+          create(:fact, fact_type: described_class::Types::BIRTH_DATE, date_string: Time.zone.today.strftime('%F')),
+          create(
+            :fact,
+            fact_type: described_class::Types::BIRTH_DATE,
+            date_string: (Time.zone.today + 1.day).strftime('%v')
+          ),
+          create(
+            :fact,
+            fact_type: described_class::Types::BIRTH_DATE,
+            date_string: (Time.zone.today + 2.days).strftime('%A %-d %B %Y')
+          ),
+          create(
+            :fact,
+            fact_type: described_class::Types::BIRTH_DATE,
+            date_string: (Time.zone.today + 3.days).strftime('%D')
+          )
+        ]
+      end
+
+      it 'correctly compares the various formats' do
+        expect(birthdays_in_range).to eq in_range_birthdays
+      end
+    end
+
+    context 'when there are birthdays outside the given range' do
+      let!(:out_of_range_birthdays) do
+        Array.new(3) do |i|
+          create(
+            :fact,
+            fact_type: described_class::Types::BIRTH_DATE,
+            date_string: (Time.zone.today + (i + 10).days).strftime('%B %-d, %Y')
+          )
+        end
+      end
+
+      it 'does not return birthdays outside the given range' do
+        expect(birthdays_in_range & out_of_range_birthdays).to eq []
+      end
+    end
+
+    context 'when there are more matching birthdays than the given limit' do
+      let(:birthday_limit) { 2 }
+
+      it 'returns a limited number of birthdays' do
+        expect(birthdays_in_range).to match_array in_range_birthdays[0..1]
+      end
+    end
+  end
+end

--- a/spec/models/fact_spec.rb
+++ b/spec/models/fact_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe Fact, type: :model do
   describe '.birth_dates' do
-    let!(:birth_dates) { create_list(:fact, 2, fact_type: described_class::Types::BIRTH_DATE) }
+    let!(:birth_dates) { create_list(:fact, 2, fact_type: described_class::Types::BIRTH) }
 
     it 'returns birth date facts' do
       expect(described_class.birth_dates).to match_array birth_dates
@@ -27,7 +27,7 @@ RSpec.describe Fact, type: :model do
       Array.new(3) do |i|
         create(
           :fact,
-          fact_type: described_class::Types::BIRTH_DATE,
+          fact_type: described_class::Types::BIRTH,
           date_string: (Time.zone.today + i.days).strftime('%B %-d, %Y')
         )
       end
@@ -53,8 +53,8 @@ RSpec.describe Fact, type: :model do
     context 'when there are birthdays with invalid date formats' do
       let!(:invalid_birthdays) do
         [
-          create(:fact, fact_type: described_class::Types::BIRTH_DATE, date_string: 'text'),
-          create(:fact, fact_type: described_class::Types::BIRTH_DATE, date_string: '1998')
+          create(:fact, fact_type: described_class::Types::BIRTH, date_string: 'text'),
+          create(:fact, fact_type: described_class::Types::BIRTH, date_string: '1998')
         ]
       end
 
@@ -66,20 +66,20 @@ RSpec.describe Fact, type: :model do
     context 'when there are birthdays in a variety of date formats' do
       let!(:in_range_birthdays) do
         [
-          create(:fact, fact_type: described_class::Types::BIRTH_DATE, date_string: Time.zone.today.strftime('%F')),
+          create(:fact, fact_type: described_class::Types::BIRTH, date_string: Time.zone.today.strftime('%F')),
           create(
             :fact,
-            fact_type: described_class::Types::BIRTH_DATE,
+            fact_type: described_class::Types::BIRTH,
             date_string: (Time.zone.today + 1.day).strftime('%v')
           ),
           create(
             :fact,
-            fact_type: described_class::Types::BIRTH_DATE,
+            fact_type: described_class::Types::BIRTH,
             date_string: (Time.zone.today + 2.days).strftime('%A %-d %B %Y')
           ),
           create(
             :fact,
-            fact_type: described_class::Types::BIRTH_DATE,
+            fact_type: described_class::Types::BIRTH,
             date_string: (Time.zone.today + 3.days).strftime('%D')
           )
         ]
@@ -95,7 +95,7 @@ RSpec.describe Fact, type: :model do
         Array.new(3) do |i|
           create(
             :fact,
-            fact_type: described_class::Types::BIRTH_DATE,
+            fact_type: described_class::Types::BIRTH,
             date_string: (Time.zone.today + (i + 10).days).strftime('%B %-d, %Y')
           )
         end


### PR DESCRIPTION
Issue: #66 

To add a birthday widget, you need an efficient way of querying birth dates. This is a pure SQL implementation, as Rails methods end up loading all the Persons into memory and it takes forever with large data sets. The SQL function is going to have a small performance impact because it triggers a subtransaction, but nowhere near as much as actually instantiating the every model in Rails would.

I've followed the linting rules and attempted to replicate the same patterns in the rest of the code but some of the PR is new  concepts in the codebase so I just had to make some educated guesses.

There is a bit of complexity involved because Postgres doesn't safely handle casting failures, so it needs a function to test the date string and catch exceptions. If a date string can't be casted to date, it is ignored - that seemed to be the most sensible behaviour if someone hasn't provided an exact date, or has provided something completely invalid.

I've done some manual testing with 1000 persons with birthdays and it seems scalable and performant.

I've moved the birth fact type into a constants module to avoid having to repeat a string constant all over the codebase.

I've also added the Timecop gem because testing based on date can become brittle at certain times of day if you don't set the time manually.