### PR TITLE
Add recent birthdays widget to Home

### DIFF
--- a/app/assets/stylesheets/application/home.scss
+++ b/app/assets/stylesheets/application/home.scss
@@ -4,6 +4,7 @@
   opacity: 0.65;
 }
 
-.recent-updates {
+.recent-widgets {
   min-width: 500px;
+  margin: 5px;
 }

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -2,12 +2,14 @@
 
 # Controller for any 'home' actions
 class HomeController < ApplicationController
+  RECENT_BIRTHDAYS_LIMIT = 5
+  RECENT_BIRTHDAYS_RANGE = 1.month
+
   def index
-    if Setting.show_recent_updates
-      @recent_updates = recent_updates
-    else
-      skip_authorization
-    end
+    @recent_updates = recent_updates if Setting.show_recent_updates
+    @recent_birthdays = recent_birthdays if Setting.show_recent_birthdays
+
+    skip_authorization if @recent_updates.nil? && @recent_birthdays.nil?
   end
 
   private
@@ -27,4 +29,11 @@ class HomeController < ApplicationController
     updates
   end
 
+  def recent_birthdays
+    birthdays = Fact.birthdays_in_range(
+      Time.zone.today, Time.zone.today + RECENT_BIRTHDAYS_RANGE, RECENT_BIRTHDAYS_LIMIT
+    )
+    authorize_list birthdays.to_a
+    birthdays
+  end
 end

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -3,7 +3,7 @@
 # RailsSettings Model
 class Setting < RailsSettings::Base
   # When this file is updated, bump the cache_prefix
-  cache_prefix { '1' }
+  cache_prefix { '2' }
 
   field :site_title, default: 'Geneac'
   field :site_tagline, default: 'Genealogy for maniacs!'
@@ -11,4 +11,5 @@ class Setting < RailsSettings::Base
   field :require_login, type: :boolean, default: false
   field :restrict_living_info, type: :boolean, default: true
   field :show_recent_updates, type: :boolean, default: true
+  field :show_recent_birthdays, type: :boolean, default: true
 end

--- a/app/views/home/index.haml
+++ b/app/views/home/index.haml
@@ -14,7 +14,12 @@
           %button.btn.btn-secondary{ type: 'submit' }= t('nav.search')
   .row
     - if setting(:show_recent_updates) && @recent_updates
-      .recent-updates.col-4.p-4.frosted-background
+      .recent-widgets.col-4.p-4.frosted-background
         %h2.text-center= t('home.recent_updates')
         - @recent_updates.each do |recent_update|
           = render partial: 'shared/search_doc', locals: { doc: recent_update }
+    - if setting(:show_recent_birthdays) && @recent_birthdays
+      .recent-widgets.col-4.p-4.frosted-background
+        %h2.text-center= t('home.recent_birthdays')
+        - @recent_birthdays.each do |recent_birthday|
+          = render partial: 'shared/birthday', locals: { birthday: recent_birthday }

--- a/app/views/shared/_birthday.html.erb
+++ b/app/views/shared/_birthday.html.erb
@@ -1,0 +1,4 @@
+<div class="mb-3">
+  <b><%= link_to birthday.factable.title, birthday.factable.url_path %></b><br>
+  <i><%= birthday.date.strftime('%B %-d, %Y') %></i>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -44,6 +44,7 @@ en:
     edit_page: 'Edit Page'
   home:
     recent_updates: 'Recent Updates'
+    recent_birthdays: 'Recent Birthdays'
   users:
     edit_profile: 'Edit Profile'
     edit_history: 'Recent Edits'
@@ -77,6 +78,8 @@ en:
     attributes:
       show_recent_updates:
         name: 'Show "Recent Updates" on home page'
+      show_recent_birthdays:
+        name: 'Show "Recent Birthdays" on home page'
       require_login:
         name: 'Require users to be signed in to view all data'
       restrict_living_info:

--- a/spec/requests/home_request_spec.rb
+++ b/spec/requests/home_request_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Home', type: :request do
+  describe '#index' do
+    let(:birthday_setting) { true }
+    let(:recent_birthdays) do
+      Array.new(3) do |i|
+        Fact.new(
+          fact_type: Fact::Types::BIRTH_DATE,
+          date_string: (Time.zone.today + i.days - 100.years).strftime('%B %-d, %Y'),
+          factable: Person.new
+        )
+      end
+    end
+
+    before do
+      allow(Setting).to receive(:require_login).and_return(false)
+      allow(Setting).to receive(:show_recent_birthdays).and_return(birthday_setting)
+      allow(Fact).to receive(:birthdays_in_range).and_return(recent_birthdays)
+      get root_path
+    end
+
+    context "when the 'show recent birthdays' setting is true" do
+      it 'returns recent birthdays' do
+        expect(assigns(:recent_birthdays)).to match_array recent_birthdays
+      end
+    end
+
+    context "when the 'show recent birthdays' setting is false" do
+      let(:birthday_setting) { false }
+
+      it 'does not return recent birthdays' do
+        expect(assigns(:recent_birthdays)).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
Issue: #66 

This adds the recent birthdays widget to the Home screen when `show_recent_birthdays` is enabled in the settings, as pictured below. I've added a little margin to the widgets because they were merging together and it looked kinda odd.

<img width="1041" alt="Screenshot 2021-10-03 at 19 05 02" src="https://user-images.githubusercontent.com/4738124/135932801-aed1d7b8-67b0-4d73-b931-281a6d3e4dd2.png">
